### PR TITLE
fix lucide-solid

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -53,9 +53,9 @@ export function frameworkImportPath(framework, options) {
 		case "react":
 		case "vue":
 		case "vue-next":
-		case "solid":
 		case "preact":
 			return `/dist/${options.importMode}/icons/`;
+		case "solid":
 		default:
 			return "/icons/";
 	}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -55,7 +55,6 @@ export function frameworkImportPath(framework, options) {
 		case "vue-next":
 		case "preact":
 			return `/dist/${options.importMode}/icons/`;
-		case "solid":
 		default:
 			return "/icons/";
 	}


### PR DESCRIPTION
`/dist/esm/icons/` is not the correct path for lucide-solid. This PR fixes it. See a minimal reproduction here: https://github.com/Tnixc/lucide-solid-min-reproduction

```
[vite] Pre-transform error: Missing "./dist/esm/icons/chevron-down" specifier in "lucide-solid" package
```

`/icons/` is correct.