### PR TITLE
ci: fix auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -39,6 +39,6 @@ jobs:
 
             > [!NOTE]
             > This is [a fully-automated release](https://github.com/WarningImHack3r/vite-plugin-lucide-preprocess#auto-updater).
-            > Despite its content being manually checked after its release, it might be incorrect or potentially break some compatibility with Lucide.
+            > Despite its content being manually checked after its release, it might be incorrect or potentially break some compatibility with Lucide.  
             > If you happen to notice any issue I might not be aware of or actively working on, please open an issue.
           token: ${{ secrets.WORKFLOW_PAT }}


### PR DESCRIPTION
Auto-release has been broken since a tiny modification I made in 125896c5a621bbb318b73b82db1f9521ed6af990. Let's figure out what it is by running a minimal version here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to amend the latest commit during automation, ensuring generated updates are included without creating extra commits.
  * Streamlines commit history in the release process.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->